### PR TITLE
Pin action versions to commit hashes

### DIFF
--- a/.github/workflows/run-update-sensor.yml
+++ b/.github/workflows/run-update-sensor.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "$UV_VERSION"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -77,7 +77,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "$UV_VERSION"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -123,7 +123,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "$UV_VERSION"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/run-update-sensor.yml
+++ b/.github/workflows/run-update-sensor.yml
@@ -20,14 +20,14 @@ jobs:
       OVERPASS_API_NAME: ${{ vars.OVERPASS_API_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "$UV_VERSION"
           enable-cache: true
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: ".python-version"
       - name: Get Day of Week
@@ -73,14 +73,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "$UV_VERSION"
           enable-cache: true
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: ".python-version"
       - name: Install the project
@@ -119,14 +119,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "$UV_VERSION"
           enable-cache: true
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: ".python-version"
       - name: Get Day of Week

--- a/.github/workflows/test-data-scripts.yml
+++ b/.github/workflows/test-data-scripts.yml
@@ -13,14 +13,14 @@ jobs:
     name: Run unit tests with pytest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "$UV_VERSION"
           enable-cache: true
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: ".python-version"
       - name: Install the project

--- a/.github/workflows/test-data-scripts.yml
+++ b/.github/workflows/test-data-scripts.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "$UV_VERSION"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/src/bikespace_data/bicycle_parking/wrappers.py
+++ b/src/bikespace_data/bicycle_parking/wrappers.py
@@ -186,7 +186,7 @@ class BikeDataOSM(BikeData):
             if OVERPASS_API_URL == overpass_default
             else "un-named custom overpass server",
         )
-        print(f"Requesting OpenStreetMap data from {OVERPASS_API_NAME} (dummy change)")
+        print(f"Requesting OpenStreetMap data from {OVERPASS_API_NAME}")
 
         api = overpass.API(
             endpoint=OVERPASS_API_URL,

--- a/src/bikespace_data/bicycle_parking/wrappers.py
+++ b/src/bikespace_data/bicycle_parking/wrappers.py
@@ -186,7 +186,7 @@ class BikeDataOSM(BikeData):
             if OVERPASS_API_URL == overpass_default
             else "un-named custom overpass server",
         )
-        print(f"Requesting OpenStreetMap data from {OVERPASS_API_NAME}")
+        print(f"Requesting OpenStreetMap data from {OVERPASS_API_NAME} (dummy change)")
 
         api = overpass.API(
             endpoint=OVERPASS_API_URL,


### PR DESCRIPTION
Fix two bugs:
- setup-uv no longer supports non-specific versions, so might as well pin them all
- must use context syntax for variables not interpreted by `run`